### PR TITLE
Habilita deploy para diferentes ambientes

### DIFF
--- a/.github/actions/deploy-s3/action.yml
+++ b/.github/actions/deploy-s3/action.yml
@@ -1,5 +1,4 @@
 name: Deploy para S3
-
 description: >-
   Realiza o upload do arquivo .cmpkg gerado para o bucket S3, baixando o último release publicado do repositório e exportando o caminho do arquivo .cmpkg encontrado.
 
@@ -11,15 +10,6 @@ inputs:
   aws_secret_access_key:
     description: AWS Secret Access Key
     required: true
-
-# Outputs para reutilização em outros jobs
-outputs:
-  caminho-cmpkg:
-    description: Caminho completo do arquivo .cmpkg baixado
-    value: ${{ steps.arquivo.outputs.caminho-cmpkg }}
-  nome-cmpkg:
-    description: Nome do arquivo .cmpkg baixado
-    value: ${{ steps.arquivo.outputs.nome-cmpkg }}
 
 runs:
   using: composite
@@ -41,16 +31,6 @@ runs:
       shell: pwsh
       run: Get-ChildItem -Path ./pacote | Format-List
 
-    # Captura o caminho e o nome do arquivo .cmpkg baixado e exporta como outputs
-    - name: Obter o nome do CMPKG
-      id: arquivo
-      shell: pwsh
-      run: |
-        $caminho = Get-ChildItem -Path ./pacote -Filter *.cmpkg | Select-Object -First 1 | Select-Object -ExpandProperty FullName
-        $nome = Split-Path $caminho -Leaf
-        "caminho-cmpkg=$caminho" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "nome-cmpkg=$nome" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
     # Baixa o BuildTools.exe do último release do repositório ColibriAgile/build-tools
     - name: Baixar buildTools.exe do GitHub Releases
       uses: robinraju/release-downloader@v1
@@ -66,6 +46,8 @@ runs:
       shell: pwsh
       run: |
         ./BuildTools.exe deploy ./pacote `
+          --ambiente producao `
+          --resumo console `
           --aws-access-key "${{ inputs.aws_access_key_id }}" `
           --aws-secret-key "${{ inputs.aws_secret_access_key }}" `
           --aws-region "us-east-1"

--- a/BuildTools.Testes/Commands/DeployCommandTestes.cs
+++ b/BuildTools.Testes/Commands/DeployCommandTestes.cs
@@ -1,0 +1,721 @@
+namespace BuildTools.Testes.Commands;
+
+using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
+using BuildTools.Commands;
+using BuildTools.Models;
+using BuildTools.Services;
+using Spectre.Console.Testing;
+
+[ExcludeFromCodeCoverage]
+public sealed class DeployCommandTestes
+{
+    private readonly TestConsole _console = new();
+    private readonly IDeployService _deployService = Substitute.For<IDeployService>();
+    private readonly Option<string> _resumoOption = new(aliases: ["--resumo", "-r"]);
+    private readonly RootCommand _rootCommand = new("Colibri BuildTools - Deploy de soluções");
+    private readonly Option<bool> _semCorOption = new(aliases: ["--sem-cor", "-sc"]);
+    private readonly Option<bool> _silenciosoOption = new(aliases: ["--silencioso", "-s"]);
+
+    public DeployCommandTestes()
+    {
+        var cmd = new DeployCommand(_silenciosoOption, _semCorOption, _resumoOption, _deployService, _console);
+        _rootCommand.AddGlobalOption(_resumoOption);
+        _rootCommand.AddGlobalOption(_silenciosoOption);
+        _rootCommand.AddGlobalOption(_semCorOption);
+        _rootCommand.AddCommand(cmd);
+    }    [Fact]
+    public async Task InvokeAsync_QuandoAmbienteInvalido_DeveRetornarErro()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE_INVALIDO = "ambiente_invalido";
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE_INVALIDO
+            ]
+        );
+
+        // Assert
+        result.ShouldNotBe(0);
+
+        // O System.CommandLine pode enviar erros de validação para stderr ou usar outro mecanismo
+        // Vamos testar se o deployment service não foi chamado devido ao erro de validação
+        await _deployService.DidNotReceive().ExecutarDeployAsync
+        (
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<string?>()
+        );
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoAmbientePadrao_DeveUsarDesenvolvimento()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                "desenvolvimento",
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                "desenvolvimento",
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            );
+    }
+
+    [Theory]
+    [InlineData("desenvolvimento")]
+    [InlineData("producao")]
+    [InlineData("stage")]
+    public async Task InvokeAsync_QuandoAmbienteValido_DeveExecutarComSucesso(string ambiente)
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                ambiente,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", ambiente
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                ambiente,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            );
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoComFalhas_DeveExibirAvisoFalhas()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoComFalhas();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("WARN");
+        _console.Output.ShouldContain("Alguns arquivos falharam");
+        _console.Output.ShouldContain("Falhas: 1");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoCredenciaisAWS_DevePassarParametrosCorretos()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+        const string AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+        const string AWS_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        const string AWS_REGION = "us-west-2";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                AWS_ACCESS_KEY,
+                AWS_SECRET_KEY,
+                AWS_REGION
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--aws-access-key", AWS_ACCESS_KEY,
+                "--aws-secret-key", AWS_SECRET_KEY,
+                "--aws-region", AWS_REGION
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                AWS_ACCESS_KEY,
+                AWS_SECRET_KEY,
+                AWS_REGION
+            );
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoDeployComSucesso_DeveExibirMensagemDeSucesso()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("SUCCESS");
+        _console.Output.ShouldContain("Deploy concluído");
+        _console.Output.ShouldContain("Arquivos processados: 2");
+        _console.Output.ShouldContain("Enviados: 2");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoDeployFalha_DeveExibirMensagemDeErro()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+        const string MENSAGEM_ERRO = "Falha ao executar deploy";
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(Task.FromException<DeployResultado>(new Exception(MENSAGEM_ERRO)));
+
+        // Act
+        var res = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE
+            ]
+        );
+
+        // Assert
+        res.ShouldBe(1);
+        _console.Output.ShouldContain("ERROR");
+        _console.Output.ShouldContain(MENSAGEM_ERRO);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoForcar_DevePassarParametroCorreto()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                true,
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--forcar"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                true,
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            );
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoMarketplaceUrl_DevePassarParametroCorreto()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+        const string MARKETPLACE_URL = "https://marketplace.exemplo.com";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                MARKETPLACE_URL,
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--mkt-url", MARKETPLACE_URL
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                MARKETPLACE_URL,
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            );
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoResumoConsole_DeveExibirResumoConsole()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--resumo", "console"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("Arquivos processados: 2");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoResumoMarkdown_DeveExibirResumoMarkdown()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--resumo", "markdown"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("# Relatório de Deploy");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoSemCor_DeveDesabilitarAnsi()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--sem-cor"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Profile.Capabilities.Ansi.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoSilencioso_NaoDeveExibirMensagens()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--silencioso"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldNotContain("INFO");
+        _console.Output.ShouldNotContain("SUCCESS");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoSimulado_DevePassarParametroCorreto()
+    {
+        // Arrange
+        const string PASTA = @"C:\pasta";
+        const string AMBIENTE = "desenvolvimento";
+
+        var resultado = CriarDeployResultadoSucesso();
+
+        _deployService
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                true,
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            )
+            .Returns(resultado);
+
+        // Act
+        var result = await _rootCommand.InvokeAsync
+        (
+            [
+                "deploy",
+                PASTA,
+                "--ambiente", AMBIENTE,
+                "--simulado"
+            ]
+        );
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("(SIMULADO)");
+
+        await _deployService
+            .Received(1)
+            .ExecutarDeployAsync
+            (
+                PASTA,
+                AMBIENTE,
+                Arg.Any<string?>(),
+                true,
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>()
+            );
+    }
+
+    private static DeployResultado CriarDeployResultadoComFalhas()
+        => new()
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote1.cmpkg"
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    MensagemErro = "Falha no upload"
+                }
+            ],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(3.1)
+        };
+
+    private static DeployResultado CriarDeployResultadoSucesso()
+        => new()
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote1.cmpkg",
+                    Manifesto = new()
+                    {
+                        Nome = "Pacote 1",
+                        Versao = "1.0.0",
+                        Develop = true,
+                        SiglaEmpresa = "EMPRESA1"
+                    }
+                },
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    NomeArquivoS3 = "pacote2.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote2.cmpkg",
+                    Manifesto = new()
+                    {
+                        Nome = "Pacote 2",
+                        Versao = "2.0.0",
+                        Develop = true,
+                        SiglaEmpresa = "EMPRESA2"
+                    }
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(5.2)
+        };
+}

--- a/BuildTools.Testes/Resumos/ResumoDeployTestes.cs
+++ b/BuildTools.Testes/Resumos/ResumoDeployTestes.cs
@@ -1,0 +1,537 @@
+using System.Diagnostics.CodeAnalysis;
+using BuildTools.Models;
+using BuildTools.Resumos;
+using Spectre.Console.Testing;
+
+namespace BuildTools.Testes.Resumos;
+
+/// <summary>
+/// Testes para ResumoDeployMarkdown.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class ResumoDeployMarkdownTestes
+{
+    [Fact]
+    public void ExibirRelatorio_QuandoTodosArquivosEnviados_DeveExibirResumoCorreto()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoSucesso();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("# Relatório de Deploy");
+        output.ShouldContain("## Resumo");
+        output.ShouldContain("- **Ambiente**: desenvolvimento");
+        output.ShouldContain("- **URL Marketplace**: https://marketplace.exemplo.com");
+        output.ShouldContain("- **Simulado**: Não");
+        output.ShouldContain("- **Tempo de Execução**: 5,2s");
+        output.ShouldContain("- **Arquivos Enviados**: 2");
+        output.ShouldContain("- **Arquivos Ignorados**: 0");
+        output.ShouldContain("- **Arquivos com Falha**: 0");
+        output.ShouldContain("## Arquivos Enviados com Sucesso");
+        output.ShouldContain("### pacote1.cmpkg");
+        output.ShouldContain("- **Pacote**: MeuPacote");
+        output.ShouldContain("- **Versão**: 1.0.0");
+        output.ShouldContain("- **Desenvolvimento**: Não");
+        output.ShouldContain("- **URL S3**: [pacote1.cmpkg](https://s3.amazonaws.com/bucket/pacote1.cmpkg)");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoComFalhas_DeveExibirSecaoFalhas()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoComFalhas();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("# Relatório de Deploy");
+        output.ShouldContain("- **Arquivos com Falha**: 1");
+        output.ShouldContain("## Arquivos com Falha");
+        output.ShouldContain("- **pacote2.cmpkg**: Falha no upload para S3");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoComIgnorados_DeveExibirSecaoIgnorados()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoComIgnorados();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("# Relatório de Deploy");
+        output.ShouldContain("- **Arquivos Ignorados**: 1");
+        output.ShouldContain("## Arquivos Ignorados");
+        output.ShouldContain("- **pacote3.cmpkg**: Arquivo já existe no S3");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoSimulado_DeveExibirSimuladoSim()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoSimulado();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("- **Simulado**: Sim");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoManifestoComEmpresa_DeveExibirEmpresa()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoComEmpresa();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("- **Empresa**: ACME");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoSemArquivosEnviados_NaoDeveExibirSecaoEnviados()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoVazio();
+        var resumo = new ResumoDeployMarkdown(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("# Relatório de Deploy");
+        output.ShouldNotContain("## Arquivos Enviados com Sucesso");
+        output.ShouldNotContain("## Arquivos com Falha");
+        output.ShouldNotContain("## Arquivos Ignorados");
+    }
+
+    private static DeployResultado CriarDeployResultadoSucesso()
+        => new()
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote1.cmpkg",
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "MeuPacote",
+                        Versao = "1.0.0",
+                        Develop = false
+                    }
+                },
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    NomeArquivoS3 = "pacote2.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote2.cmpkg",
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "OutroPacote",
+                        Versao = "2.1.0",
+                        Develop = true
+                    }
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(5.2)
+        };
+
+    private static DeployResultado CriarDeployResultadoComFalhas()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    NomeArquivoS3 = "pacote2.cmpkg",
+                    MensagemErro = "Falha no upload para S3"
+                }
+            ],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(3.1)
+        };
+
+    private static DeployResultado CriarDeployResultadoComIgnorados()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote3.cmpkg",
+                    NomeArquivoS3 = "pacote3.cmpkg",
+                    MensagemErro = "Arquivo já existe no S3"
+                }
+            ],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(1.5)
+        };
+
+    private static DeployResultado CriarDeployResultadoSimulado()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = true,
+            TempoExecucao = TimeSpan.FromSeconds(0.1)
+        };
+
+    private static DeployResultado CriarDeployResultadoComEmpresa()
+        => new()
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote1.cmpkg",
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "PacoteEmpresa",
+                        Versao = "1.0.0",
+                        Develop = false,
+                        SiglaEmpresa = "ACME"
+                    }
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "producao",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(2.3)
+        };
+
+    private static DeployResultado CriarDeployResultadoVazio()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(0.1)
+        };
+}
+
+/// <summary>
+/// Testes para ResumoDeployConsole.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class ResumoDeployConsoleTestes
+{
+    [Fact]
+    public void ExibirRelatorio_QuandoTodosArquivosEnviados_DeveExibirResumoCorreto()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoSucesso();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("Propriedade");
+        output.ShouldContain("Valor");
+        output.ShouldContain("Ambiente");
+        output.ShouldContain("desenvolvimento");
+        output.ShouldContain("URL Marketplace");
+        output.ShouldContain("https://marketplace.exemplo.com");
+        output.ShouldContain("Simulado");
+        output.ShouldContain("Não");
+        output.ShouldContain("Tempo de Execução");
+        output.ShouldContain("5,2s");
+        output.ShouldContain("Arquivos Enviados");
+        output.ShouldContain("2");
+        output.ShouldContain("Arquivos Ignorados");
+        output.ShouldContain("0");
+        output.ShouldContain("Arquivos com Falha");
+        output.ShouldContain("0");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoComArquivosEnviados_DeveExibirListaArquivos()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoSucesso();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("Arquivos enviados com sucesso:");
+        output.ShouldContain("✓");
+        output.ShouldContain("pacote1.cmpkg");
+        output.ShouldContain("(MeuPacote v1.0.0)");
+        output.ShouldContain("URL: https://s3.amazonaws.com/bucket/pacote1.cmpkg");
+        output.ShouldContain("pacote2.cmpkg");
+        output.ShouldContain("(OutroPacote v2.1.0)");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoComFalhas_DeveExibirListaFalhas()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoComFalhas();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("Arquivos com falha:");
+        output.ShouldContain("✗");
+        output.ShouldContain("pacote2.cmpkg");
+        output.ShouldContain("Falha no upload para S3");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoComIgnorados_DeveExibirListaIgnorados()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoComIgnorados();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("Arquivos ignorados:");
+        output.ShouldContain("⚠");
+        output.ShouldContain("pacote3.cmpkg");
+        output.ShouldContain("Arquivo já existe no S3");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoSimulado_DeveExibirSimuladoSim()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoSimulado();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("Simulado");
+        output.ShouldContain("Sim");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoSemArquivosEnviados_NaoDeveExibirSecaoEnviados()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = CriarDeployResultadoVazio();
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldNotContain("Arquivos enviados com sucesso:");
+        output.ShouldNotContain("Arquivos com falha:");
+        output.ShouldNotContain("Arquivos ignorados:");
+    }
+
+    [Fact]
+    public void ExibirRelatorio_QuandoArquivoSemUrl_NaoDeveExibirUrl()
+    {
+        // Arrange
+        var console = new TestConsole();
+        var resultado = new DeployResultado
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = null, // Sem URL
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "MeuPacote",
+                        Versao = "1.0.0",
+                        Develop = false
+                    }
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(1.0)
+        };
+
+        var resumo = new ResumoDeployConsole(console, resultado);
+
+        // Act
+        resumo.ExibirRelatorio();
+        var output = console.Output;
+
+        // Assert
+        output.ShouldContain("pacote1.cmpkg");
+        output.ShouldNotContain("URL:");
+    }
+
+    private static DeployResultado CriarDeployResultadoSucesso()
+        => new()
+        {
+            ArquivosEnviados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote1.cmpkg",
+                    NomeArquivoS3 = "pacote1.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote1.cmpkg",
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "MeuPacote",
+                        Versao = "1.0.0",
+                        Develop = false
+                    }
+                },
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    NomeArquivoS3 = "pacote2.cmpkg",
+                    UrlS3 = "https://s3.amazonaws.com/bucket/pacote2.cmpkg",
+                    Manifesto = new ManifestoDeploy
+                    {
+                        Nome = "OutroPacote",
+                        Versao = "2.1.0",
+                        Develop = true
+                    }
+                }
+            ],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(5.2)
+        };
+
+    private static DeployResultado CriarDeployResultadoComFalhas()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote2.cmpkg",
+                    NomeArquivoS3 = "pacote2.cmpkg",
+                    MensagemErro = "Falha no upload para S3"
+                }
+            ],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(3.1)
+        };
+
+    private static DeployResultado CriarDeployResultadoComIgnorados()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados =
+            [
+                new DeployArquivo
+                {
+                    CaminhoArquivo = @"C:\pasta\pacote3.cmpkg",
+                    NomeArquivoS3 = "pacote3.cmpkg",
+                    MensagemErro = "Arquivo já existe no S3"
+                }
+            ],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(1.5)
+        };
+
+    private static DeployResultado CriarDeployResultadoSimulado()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = true,
+            TempoExecucao = TimeSpan.FromSeconds(0.1)
+        };
+
+    private static DeployResultado CriarDeployResultadoVazio()
+        => new()
+        {
+            ArquivosEnviados = [],
+            ArquivosIgnorados = [],
+            ArquivosFalharam = [],
+            Ambiente = "desenvolvimento",
+            UrlMarketplace = "https://marketplace.exemplo.com",
+            Simulado = false,
+            TempoExecucao = TimeSpan.FromSeconds(0.1)
+        };
+}

--- a/BuildTools.Testes/Resumos/ResumoDeployTestes.cs
+++ b/BuildTools.Testes/Resumos/ResumoDeployTestes.cs
@@ -29,7 +29,7 @@ public sealed class ResumoDeployMarkdownTestes
         output.ShouldContain("- **Ambiente**: desenvolvimento");
         output.ShouldContain("- **URL Marketplace**: https://marketplace.exemplo.com");
         output.ShouldContain("- **Simulado**: Não");
-        output.ShouldContain("- **Tempo de Execução**: 5,2s");
+        output.ShouldContain($"- **Tempo de Execução**: {resultado.TempoExecucao.TotalSeconds}s"); // Workaround para o ponto ou virgula que muda conforme cultura
         output.ShouldContain("- **Arquivos Enviados**: 2");
         output.ShouldContain("- **Arquivos Ignorados**: 0");
         output.ShouldContain("- **Arquivos com Falha**: 0");
@@ -288,7 +288,7 @@ public sealed class ResumoDeployConsoleTestes
         output.ShouldContain("Simulado");
         output.ShouldContain("Não");
         output.ShouldContain("Tempo de Execução");
-        output.ShouldContain("5,2s");
+        output.ShouldContain($"{resultado.TempoExecucao.TotalSeconds}s");
         output.ShouldContain("Arquivos Enviados");
         output.ShouldContain("2");
         output.ShouldContain("Arquivos Ignorados");

--- a/BuildTools.Testes/Services/DateTimeProviderTestes.cs
+++ b/BuildTools.Testes/Services/DateTimeProviderTestes.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using BuildTools.Services;
-using Shouldly;
-using Xunit;
 
 namespace BuildTools.Testes.Services;
 

--- a/BuildTools/Commands/DeployCommand.cs
+++ b/BuildTools/Commands/DeployCommand.cs
@@ -147,22 +147,21 @@ public sealed class DeployCommand : Command
     {
         _ambienteOption.SetDefaultValue("desenvolvimento");
 
-        _ambienteOption.AddValidator(result =>
-        {
-            var valor = result.GetValueForOption(_ambienteOption);
-
-            if (string.IsNullOrEmpty(valor))
+        _ambienteOption.AddValidator
+        (
+            result =>
             {
-                return;
-            }
+                var valor = result.GetValueForOption(_ambienteOption);
 
-            var ambientesValidos = new[] { "desenvolvimento", "producao", "stage" };
+                if (string.IsNullOrEmpty(valor))
+                    return;
 
-            if (!ambientesValidos.Contains(valor, StringComparer.OrdinalIgnoreCase))
-            {
-                result.ErrorMessage = $"Ambiente '{valor}' inválido. Valores permitidos: {string.Join(", ", ambientesValidos)}";
+                var ambientesValidos = new[] { "desenvolvimento", "producao", "stage" };
+
+                if (!ambientesValidos.Contains(valor, StringComparer.OrdinalIgnoreCase))
+                    result.ErrorMessage = $"Ambiente '{valor}' inválido. Valores permitidos: {string.Join(", ", ambientesValidos)}";
             }
-        });
+        );
     }
 
     /// <summary>

--- a/BuildTools/Resumos/ResumoDeployMarkdown.cs
+++ b/BuildTools/Resumos/ResumoDeployMarkdown.cs
@@ -98,7 +98,7 @@ public sealed class ResumoDeployMarkdown : IResumo
                 sb.AppendLine($"- **Empresa**: {arquivo.Manifesto.SiglaEmpresa}");
 
             if (!string.IsNullOrEmpty(arquivo.UrlS3))
-                sb.AppendLine($"- **URL S3**: [{arquivo.UrlS3}]({arquivo.UrlS3})");
+                sb.AppendLine($"- **URL S3**: [{arquivo.NomeArquivoS3}]({arquivo.UrlS3})");
 
             sb.AppendLine();
         }

--- a/BuildTools/Statup.cs
+++ b/BuildTools/Statup.cs
@@ -31,7 +31,7 @@ public static class Startup
         services.AddSingleton<IManifestoService, ManifestoService>();
         services.AddSingleton<IManifestoGeradorService, ManifestoGeradorService>();
         services.AddSingleton<IArquivoService, ArquivoService>();
-        
+
         // Serviços de Deploy
         services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
         services.AddSingleton<IDeployService, DeployService>();


### PR DESCRIPTION
Permite o deploy da aplicação para os ambientes de desenvolvimento, produção e stage,
adicionando flags para configurar o comportamento do deploy.

Adiciona testes automatizados para garantir o correto funcionamento do comando de deploy
e dos resumos gerados.

Realiza melhorias na exibição dos resumos de deploy, tanto no console quanto em formato Markdown,
incluindo informações sobre arquivos enviados, ignorados e com falha, além de detalhes do manifesto.