### PR TITLE
Fix: corrige o upload de pacote para S3 e a geração de token jwt,

### DIFF
--- a/BuildTools.Testes/Commands/DeployCommandTestes.cs
+++ b/BuildTools.Testes/Commands/DeployCommandTestes.cs
@@ -1,11 +1,12 @@
-namespace BuildTools.Testes.Commands;
-
 using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using BuildTools.Commands;
 using BuildTools.Models;
 using BuildTools.Services;
+using BuildTools.Validation;
 using Spectre.Console.Testing;
+
+namespace BuildTools.Testes.Commands;
 
 [ExcludeFromCodeCoverage]
 public sealed class DeployCommandTestes
@@ -16,15 +17,18 @@ public sealed class DeployCommandTestes
     private readonly RootCommand _rootCommand = new("Colibri BuildTools - Deploy de soluções");
     private readonly Option<bool> _semCorOption = new(aliases: ["--sem-cor", "-sc"]);
     private readonly Option<bool> _silenciosoOption = new(aliases: ["--silencioso", "-s"]);
+    private readonly Option<string> _ambienteOption = AmbienteValidator.CriarOpcaoAmbiente();
 
     public DeployCommandTestes()
     {
-        var cmd = new DeployCommand(_silenciosoOption, _semCorOption, _resumoOption, _deployService, _console);
+        var cmd = new DeployCommand(_silenciosoOption, _semCorOption, _resumoOption, _ambienteOption, _deployService, _console);
         _rootCommand.AddGlobalOption(_resumoOption);
         _rootCommand.AddGlobalOption(_silenciosoOption);
         _rootCommand.AddGlobalOption(_semCorOption);
         _rootCommand.AddCommand(cmd);
-    }    [Fact]
+    }
+
+    [Fact]
     public async Task InvokeAsync_QuandoAmbienteInvalido_DeveRetornarErro()
     {
         // Arrange
@@ -37,7 +41,8 @@ public sealed class DeployCommandTestes
             [
                 "deploy",
                 PASTA,
-                "--ambiente", AMBIENTE_INVALIDO
+                "--ambiente",
+                AMBIENTE_INVALIDO
             ]
         );
 

--- a/BuildTools.Testes/Commands/NotificarMarketCommandTestes.cs
+++ b/BuildTools.Testes/Commands/NotificarMarketCommandTestes.cs
@@ -1,0 +1,220 @@
+using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
+using BuildTools.Commands;
+using BuildTools.Models;
+using BuildTools.Services;
+using Spectre.Console.Testing;
+
+namespace BuildTools.Testes.Commands;
+
+using NSubstitute.ExceptionExtensions;
+
+/// <summary>
+/// Testes para a classe <see cref="NotificarMarketCommand"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class NotificarMarketCommandTestes
+{
+    private const string PASTA_TESTE = @"C:\teste\pasta";
+    private const string AMBIENTE_DESENVOLVIMENTO = "desenvolvimento";
+    private const string URL_MARKETPLACE_CUSTOM = "https://custom.marketplace.com";
+    private const string URL_MARKETPLACE_PADRAO = "https://www.mycolibri.com.br";
+    private const string NOME_PACOTE = "TestePacote";
+    private const string VERSAO_PACOTE = "1.0.0";
+
+    private readonly IMarketplaceService _marketplaceService = Substitute.For<IMarketplaceService>();
+    private readonly IManifestoService _manifestoService = Substitute.For<IManifestoService>();
+    private readonly TestConsole _console = new();
+    private readonly NotificarMarketCommand _command;
+
+    private readonly Option<bool> _silenciosoOption = new(["--silencioso", "-sl"]) { IsRequired = false };
+    private readonly Option<bool> _semCorOption = new(["--sem-cor", "-sc"]) { IsRequired = false };
+    private readonly Option<string> _ambienteOption = new(["--ambiente", "-a"]) { IsRequired = false };
+
+    public NotificarMarketCommandTestes()
+    {
+        _ambienteOption.SetDefaultValue(AMBIENTE_DESENVOLVIMENTO);
+
+        _command = new NotificarMarketCommand
+        (
+            _silenciosoOption,
+            _semCorOption,
+            _ambienteOption,
+            _marketplaceService,
+            _manifestoService,
+            _console
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ComParametrosValidos_DeveNotificarMarketplace()
+    {
+        // Arrange
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null).Returns(URL_MARKETPLACE_PADRAO);
+        _marketplaceService.NotificarPacoteAsync(URL_MARKETPLACE_PADRAO, manifesto).Returns(true);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE}");
+
+        // Assert
+        result.ShouldBe(0);
+        await _manifestoService.Received(1).LerManifestoDeployAsync(PASTA_TESTE);
+        _marketplaceService.Received(1).ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null);
+        await _marketplaceService.Received(1).NotificarPacoteAsync(URL_MARKETPLACE_PADRAO, manifesto);
+    }
+
+    [Fact]
+    public async Task Handle_ComUrlMarketplaceCustomizada_DeveUsarUrlCustomizada()
+    {
+        // Arrange
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, URL_MARKETPLACE_CUSTOM).Returns(URL_MARKETPLACE_CUSTOM);
+        _marketplaceService.NotificarPacoteAsync(URL_MARKETPLACE_CUSTOM, manifesto).Returns(true);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE} --mkt-url {URL_MARKETPLACE_CUSTOM}");
+
+        // Assert
+        result.ShouldBe(0);
+        _marketplaceService.Received(1).ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, URL_MARKETPLACE_CUSTOM);
+        await _marketplaceService.Received(1).NotificarPacoteAsync(URL_MARKETPLACE_CUSTOM, manifesto);
+    }
+
+    [Fact]
+    public async Task Handle_ComAmbienteEspecifico_DeveUsarAmbiente()
+    {
+        // Arrange
+        const string AMBIENTE_HOMOLOGACAO = "homologacao";
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_HOMOLOGACAO, null).Returns("https://mycolibri-homolog.ciasc.gov.br");
+        _marketplaceService.NotificarPacoteAsync(Arg.Any<string>(), manifesto).Returns(true);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE} --ambiente {AMBIENTE_HOMOLOGACAO}");
+
+        // Assert
+        result.ShouldBe(0);
+        _marketplaceService.Received(1).ObterUrlMarketplace(AMBIENTE_HOMOLOGACAO, null);
+    }
+
+    [Fact]
+    public async Task Handle_ModoSilencioso_NaoDeveExibirMensagens()
+    {
+        // Arrange
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null).Returns(URL_MARKETPLACE_PADRAO);
+        _marketplaceService.NotificarPacoteAsync(URL_MARKETPLACE_PADRAO, manifesto).Returns(true);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE} --silencioso");
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ModoSemCor_DeveDesabilitarAnsi()
+    {
+        // Arrange
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null).Returns(URL_MARKETPLACE_PADRAO);
+        _marketplaceService.NotificarPacoteAsync(URL_MARKETPLACE_PADRAO, manifesto).Returns(true);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync(["notificar-market", PASTA_TESTE, "--sem-cor"]);
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Profile.Capabilities.Ansi.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_FalhaNaNotificacao_DeveExibirMensagemDeErro()
+    {
+        // Arrange
+        var manifesto = CriarManifesto();
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE).Returns(manifesto);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null).Returns(URL_MARKETPLACE_PADRAO);
+        _marketplaceService.NotificarPacoteAsync(URL_MARKETPLACE_PADRAO, manifesto).Returns(false);
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE}");
+
+        // Assert
+        result.ShouldBe(0);
+        _console.Output.ShouldContain("ERROR");
+        _console.Output.ShouldContain("Falha na notificação do marketplace");
+    }
+
+    [Fact]
+    public async Task Handle_ExcecaoNaLeituraManifesto_DeveLancarExcecao()
+    {
+        // Arrange
+        _manifestoService.LerManifestoDeployAsync(PASTA_TESTE)
+            .ThrowsAsync(new FileNotFoundException("Arquivo não encontrado"));
+
+        var rootCommand = new RootCommand
+        {
+            _command
+        };
+
+        // Act & Assert
+        var result = await rootCommand.InvokeAsync($"notificar-market {PASTA_TESTE}");
+        result.ShouldNotBe(0);
+        _console.Output.ShouldContain("ERROR");
+        _console.Output.ShouldContain("Arquivo não encontrado");
+    }
+
+    private static ManifestoDeploy CriarManifesto()
+        => new()
+        {
+            Nome = NOME_PACOTE,
+            Versao = VERSAO_PACOTE,
+            Develop = false,
+            SiglaEmpresa = "EMP",
+            DadosCompletos = new Dictionary<string, object>
+            {
+                ["nome"] = NOME_PACOTE,
+                ["versao"] = VERSAO_PACOTE,
+                ["develop"] = false,
+                ["siglaEmpresa"] = "EMP"
+            }
+        };
+}

--- a/BuildTools.Testes/Services/DeployServiceTestes.cs
+++ b/BuildTools.Testes/Services/DeployServiceTestes.cs
@@ -177,6 +177,7 @@ public sealed class DeployServiceTestes
         // Arrange
         ConfigurarFileSystemComArquivos();
         var manifestoJson = CriarManifestoJson("TestePacote", "1.0.0", false);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, URL_MARKETPLACE_CUSTOM).Returns(URL_MARKETPLACE_CUSTOM);
 
         _fileSystem.File.ReadAllTextAsync(Arg.Any<string>())
             .Returns(manifestoJson);
@@ -185,11 +186,13 @@ public sealed class DeployServiceTestes
         Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", AWS_SECRET_KEY);
 
         // Act
-        var resultado = await _deployService.ExecutarDeployAsync(
+        var resultado = await _deployService.ExecutarDeployAsync
+        (
             PASTA_TESTES,
             AMBIENTE_DESENVOLVIMENTO,
             URL_MARKETPLACE_CUSTOM,
-            simulado: true);
+            simulado: true
+        );
 
         // Assert
         resultado.UrlMarketplace.ShouldBe(URL_MARKETPLACE_CUSTOM);
@@ -201,6 +204,7 @@ public sealed class DeployServiceTestes
         // Arrange
         ConfigurarFileSystemComArquivos();
         var manifestoJson = CriarManifestoJson("TestePacote", "1.0.0", false);
+        _marketplaceService.ObterUrlMarketplace(AMBIENTE_DESENVOLVIMENTO, null).Returns("http://localhost:8888");
 
         _fileSystem.File.ReadAllTextAsync(Arg.Any<string>())
             .Returns(manifestoJson);
@@ -236,6 +240,7 @@ public sealed class DeployServiceTestes
     {
         // Arrange
         ConfigurarFileSystemComArquivos();
+        _marketplaceService.ObterUrlMarketplace(ambiente, null).Returns(urlEsperada);
         var manifestoJson = CriarManifestoJson("TestePacote", "1.0.0", false);
 
         _fileSystem.File.ReadAllTextAsync(Arg.Any<string>())

--- a/BuildTools.Testes/Services/DeployServiceTestes.cs
+++ b/BuildTools.Testes/Services/DeployServiceTestes.cs
@@ -599,7 +599,7 @@ public sealed class DeployServiceTestes
 
         // Assert
         resultado.ArquivosEnviados.ShouldHaveSingleItem();
-        resultado.ArquivosEnviados[0].NomeArquivoS3.ShouldBe("EMP-TestePacote_1_0_0.cmpkg");
+        resultado.ArquivosEnviados[0].NomeArquivoS3.ShouldBe("emp-testepacote_1_0_0.cmpkg");
     }
 
     [Fact]
@@ -623,7 +623,7 @@ public sealed class DeployServiceTestes
 
         // Assert
         resultado.ArquivosEnviados.ShouldHaveSingleItem();
-        resultado.ArquivosEnviados[0].NomeArquivoS3.ShouldBe("TestePacote_1_0_0.cmpkg");
+        resultado.ArquivosEnviados[0].NomeArquivoS3.ShouldBe("testepacote_1_0_0.cmpkg");
     }
 
     [Fact]

--- a/BuildTools.Testes/Services/MarketplaceServiceTestes.cs
+++ b/BuildTools.Testes/Services/MarketplaceServiceTestes.cs
@@ -312,6 +312,43 @@ public sealed class MarketplaceServiceTestes : IDisposable
         request.Headers.Authorization?.Parameter.ShouldBeNullOrEmpty();
     }
 
+    [Theory]
+    [InlineData("desenvolvimento", null, "https://qa-marketplace.ncrcolibri.com.br")]
+    [InlineData("stage", null, "https://qa-marketplace.ncrcolibri.com.br")]
+    [InlineData("producao", null, "https://marketplace.ncrcolibri.com.br")]
+    public void ObterUrlMarketplace_AmbienteSemUrlCustomizada_DeveRetornarUrlPadrao(string ambiente, string? urlCustomizada, string urlEsperada)
+    {
+        // Act
+        var resultado = _marketplaceService.ObterUrlMarketplace(ambiente, urlCustomizada);
+
+        // Assert
+        resultado.ShouldBe(urlEsperada);
+    }
+
+    [Theory]
+    [InlineData("desenvolvimento", "https://custom.marketplace.com")]
+    [InlineData("homologacao", "https://custom.marketplace.com")]
+    [InlineData("producao", "https://custom.marketplace.com")]
+    public void ObterUrlMarketplace_AmbienteComUrlCustomizada_DeveRetornarUrlCustomizada(string ambiente, string urlCustomizada)
+    {
+        // Act
+        var resultado = _marketplaceService.ObterUrlMarketplace(ambiente, urlCustomizada);
+
+        // Assert
+        resultado.ShouldBe(urlCustomizada);
+    }
+
+    [Fact]
+    public void ObterUrlMarketplace_AmbienteInvalido_DeveLancarArgumentException()
+    {
+        // Arrange
+        const string AMBIENTE_INVALIDO = "ambiente-inexistente";
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => _marketplaceService.ObterUrlMarketplace(AMBIENTE_INVALIDO, null))
+            .Message.ShouldContain($"Ambiente '{AMBIENTE_INVALIDO}' não é válido");
+    }
+
     private static ManifestoDeploy CriarManifesto(string nome, string versao, bool develop, string? siglaEmpresa = null)
     {
         var dadosCompletos = new Dictionary<string, object>

--- a/BuildTools.Testes/Validation/AmbienteValidatorTestes.cs
+++ b/BuildTools.Testes/Validation/AmbienteValidatorTestes.cs
@@ -54,10 +54,10 @@ public sealed class AmbienteValidatorTestes
     public void ValidarAmbiente_AmbienteComCaseDiferente_DeveValidar()
     {
         // Arrange
-        const string ambienteUpperCase = "DESENVOLVIMENTO";
+        const string AMBIENTE_UPPER_CASE = "DESENVOLVIMENTO";
 
         // Act
-        var validacao = () => AmbienteValidator.ValidarAmbiente(ambienteUpperCase);
+        var validacao = static () => AmbienteValidator.ValidarAmbiente(AMBIENTE_UPPER_CASE);
 
         // Assert
         validacao.ShouldNotThrow();

--- a/BuildTools.Testes/Validation/AmbienteValidatorTestes.cs
+++ b/BuildTools.Testes/Validation/AmbienteValidatorTestes.cs
@@ -1,0 +1,228 @@
+using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
+using BuildTools.Validation;
+
+namespace BuildTools.Testes.Validation;
+
+/// <summary>
+/// Testes para a classe <see cref="AmbienteValidator"/>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class AmbienteValidatorTestes
+{
+    private const string AMBIENTE_DESENVOLVIMENTO = "desenvolvimento";
+    private const string AMBIENTE_HOMOLOGACAO = "stage";
+    private const string AMBIENTE_PRODUCAO = "producao";
+    private const string AMBIENTE_INVALIDO = "ambiente-inexistente";
+
+    [Theory]
+    [InlineData(AMBIENTE_DESENVOLVIMENTO)]
+    [InlineData(AMBIENTE_HOMOLOGACAO)]
+    [InlineData(AMBIENTE_PRODUCAO)]
+    public void ValidarAmbiente_AmbienteValido_DeveValidar(string ambiente)
+    {
+        // Act
+        var validacao = () => AmbienteValidator.ValidarAmbiente(ambiente);
+
+        // Assert
+        validacao.ShouldNotThrow();
+    }
+
+    [Fact]
+    public void ValidarAmbiente_AmbienteInvalido_DeveLancarArgumentException()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(static () => AmbienteValidator.ValidarAmbiente(AMBIENTE_INVALIDO))
+            .Message.ShouldContain($"Ambiente '{AMBIENTE_INVALIDO}' inválido");
+    }
+
+    [Fact]
+    public void ValidarAmbiente_AmbienteNulo_DeveLancarArgumentNullException()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(static () => AmbienteValidator.ValidarAmbiente(null!));
+    }
+
+    [Fact]
+    public void ValidarAmbiente_AmbienteVazio_DeveLancarArgumentException()
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(static () => AmbienteValidator.ValidarAmbiente(string.Empty));
+    }
+
+    [Fact]
+    public void ValidarAmbiente_AmbienteComCaseDiferente_DeveValidar()
+    {
+        // Arrange
+        const string ambienteUpperCase = "DESENVOLVIMENTO";
+
+        // Act
+        var validacao = () => AmbienteValidator.ValidarAmbiente(ambienteUpperCase);
+
+        // Assert
+        validacao.ShouldNotThrow();
+    }
+
+    [Theory]
+    [InlineData("  desenvolvimento  ")]
+    [InlineData("\t\nstage\t\n")]
+    public void ValidarAmbiente_AmbienteComEspacos_DeveLancarArgumentException(string ambienteComEspacos)
+    {
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => AmbienteValidator.ValidarAmbiente(ambienteComEspacos))
+            .Message.ShouldContain("inválido");
+    }
+
+    [Fact]
+    public void CriarOpcaoAmbiente_DeveRetornarOpcaoConfigurada()
+    {
+        // Act
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+
+        // Assert
+        opcao.ShouldNotBeNull();
+        opcao.Name.ShouldBe("ambiente");
+        opcao.Aliases.ShouldContain("--ambiente");
+        opcao.Aliases.ShouldContain("-a");
+        opcao.IsRequired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CriarOpcaoAmbiente_ComValorPadraoCustomizado_DeveConfigurarCorreto()
+    {
+        // Arrange
+        const string VALOR_PADRAO_CUSTOMIZADO = "producao";
+
+        // Act
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente(VALOR_PADRAO_CUSTOMIZADO);
+
+        // Assert
+        opcao.ShouldNotBeNull();
+        opcao.Name.ShouldBe("ambiente");
+        opcao.Aliases.ShouldContain("--ambiente");
+        opcao.Aliases.ShouldContain("-a");
+        opcao.IsRequired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CriarOpcaoAmbiente_SemParametros_DeveUsarDesenvolvimentoComoPadrao()
+    {
+        // Act
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+
+        // Assert
+        opcao.ShouldNotBeNull();
+        opcao.Name.ShouldBe("ambiente");
+        opcao.IsRequired.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(AMBIENTE_DESENVOLVIMENTO)]
+    [InlineData(AMBIENTE_HOMOLOGACAO)]
+    [InlineData(AMBIENTE_PRODUCAO)]
+    public void CriarOpcaoAmbiente_ValidarComandoValido_DeveAceitarAmbiente(string ambiente)
+    {
+        // Arrange
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+        var command = new Command("test");
+        command.AddOption(opcao);
+
+        // Act
+        var parseResult = command.Parse($"--ambiente {ambiente}");
+
+        // Assert
+        parseResult.Errors.ShouldBeEmpty();
+        parseResult.GetValueForOption(opcao).ShouldBe(ambiente);
+    }
+
+    [Fact]
+    public void CriarOpcaoAmbiente_ValidarComandoInvalido_DeveRejeitarAmbiente()
+    {
+        // Arrange
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+        var command = new Command("test");
+        command.AddOption(opcao);
+
+        // Act
+        var parseResult = command.Parse($"--ambiente {AMBIENTE_INVALIDO}");
+
+        // Assert
+        parseResult.Errors.ShouldNotBeEmpty();
+        parseResult.Errors[0].Message.ShouldContain($"Ambiente '{AMBIENTE_INVALIDO}' inválido");
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("test")]
+    public void CriarOpcaoAmbiente_ValidarComandoComAmbientesInvalidos_DeveRejeitarTodos(string ambienteInvalido)
+    {
+        // Arrange
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+        var command = new Command("test");
+        command.AddOption(opcao);
+
+        // Act
+        var parseResult = command.Parse($"--ambiente {ambienteInvalido}");
+
+        // Assert
+        parseResult.Errors.ShouldNotBeEmpty();
+        parseResult.Errors[0].Message.ShouldContain("inválido");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CriarOpcaoAmbiente_ValidarComandoComAmbientesVazio_DeveRejeitarTodos(string ambienteVazio)
+    {
+        // Arrange
+        var opcao = AmbienteValidator.CriarOpcaoAmbiente();
+        var command = new Command("test");
+        command.AddOption(opcao);
+
+        // Act
+        var parseResult = command.Parse($"--ambiente {ambienteVazio}");
+
+        // Assert
+        parseResult.Errors.ShouldNotBeEmpty();
+        parseResult.Errors[0].Message.ShouldContain("Required argument missing");
+    }
+
+    [Fact]
+    public void ValidarAmbiente_TodosAmbientesValidos_DeveValidarTodos()
+    {
+        // Arrange
+        var ambientesValidos = new[] { "desenvolvimento", "producao", "stage" };
+
+        // Act & Assert
+        foreach (var ambiente in ambientesValidos)
+        {
+            var validacao = () => AmbienteValidator.ValidarAmbiente(ambiente);
+            validacao.ShouldNotThrow($"Ambiente '{ambiente}' deveria ser válido");
+        }
+    }
+
+    [Fact]
+    public void ValidarAmbiente_MensagemDeErro_DeveConterAmbientesValidos()
+    {
+        // Act & Assert
+        var exception = Should.Throw<ArgumentException>(static () => AmbienteValidator.ValidarAmbiente(AMBIENTE_INVALIDO));
+        exception.Message.ShouldContain("desenvolvimento");
+        exception.Message.ShouldContain("producao");
+        exception.Message.ShouldContain("stage");
+        exception.Message.ShouldContain("Valores permitidos:");
+    }
+
+    [Fact]
+    public void ObterAmbientesValidos_DeveRetornarTodosAmbientesValidos()
+    {
+        // Act
+        var ambientes = AmbienteValidator.ObterAmbientesValidos();
+
+        // Assert
+        ambientes.ShouldNotBeNull();
+        ambientes.Length.ShouldBe(3);
+        ambientes.ShouldContain("desenvolvimento");
+        ambientes.ShouldContain("producao");
+        ambientes.ShouldContain("stage");
+    }
+}

--- a/BuildTools/Commands/DeployCommand.cs
+++ b/BuildTools/Commands/DeployCommand.cs
@@ -112,8 +112,6 @@ public sealed class DeployCommand : Command
         AddOption(_awsAccessKeyOption);
         AddOption(_awsSecretKeyOption);
         AddOption(_awsRegionOption);
-        _deployService = deployService;
-        _console = console;
 
         this.SetHandler
         (

--- a/BuildTools/Commands/NotificarMarketCommand.cs
+++ b/BuildTools/Commands/NotificarMarketCommand.cs
@@ -1,0 +1,124 @@
+using System.CommandLine;
+using BuildTools.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
+
+namespace BuildTools.Commands;
+
+/// <summary>
+/// Comando para notificar o marketplace sobre um pacote específico.
+/// </summary>
+public sealed class NotificarMarketCommand : Command
+{
+    private readonly IMarketplaceService _marketplaceService;
+    private readonly IManifestoService _manifestoService;
+    private readonly IAnsiConsole _console;
+
+    private readonly Argument<string> _pastaArgument = new
+    (
+        name: "pasta",
+        description: "Pasta contendo o arquivo manifesto.dat"
+    );
+
+    private readonly Option<string> _marketplaceUrlOption = new
+    (
+        aliases: ["--mkt-url", "-m"],
+        description: "URL do marketplace (opcional, usa padrão do ambiente)"
+    )
+    {
+        IsRequired = false
+    };
+
+    /// <summary>
+    /// Inicializa uma nova instância da classe <see cref="NotificarMarketCommand"/>.
+    /// </summary>
+    /// <param name="silenciosoOption">Opção para execução silenciosa.</param>
+    /// <param name="semCorOption">Opção para execução sem cores.</param>    /// <param name="ambienteOption">Opção para seleção de ambiente.</param>
+    /// <param name="marketplaceService">Serviço de notificação do marketplace.</param>
+    /// <param name="manifestoService">Serviço para leitura de manifestos.</param>
+    /// <param name="console">Console para saída de informações.</param>
+    public NotificarMarketCommand
+    (
+        [FromKeyedServices("silencioso")] Option<bool> silenciosoOption,
+        [FromKeyedServices("semCor")] Option<bool> semCorOption,
+        [FromKeyedServices("ambiente")] Option<string> ambienteOption,
+        IMarketplaceService marketplaceService,
+        IManifestoService manifestoService,
+        IAnsiConsole console
+    )
+        : base("notificar-market", "Notifica o marketplace sobre um pacote específico")
+    {
+        _marketplaceService = marketplaceService;
+        _manifestoService = manifestoService;
+        _console = console;
+
+        AddArgument(_pastaArgument);
+        AddOption(ambienteOption);
+        AddOption(_marketplaceUrlOption);
+        AddOption(semCorOption);
+        AddOption(silenciosoOption);
+
+        this.SetHandler
+        (
+            context =>
+            {
+                var pasta = context.ParseResult.GetValueForArgument(_pastaArgument);
+                var ambiente = context.ParseResult.GetValueForOption(ambienteOption)!;
+                var marketplaceUrl = context.ParseResult.GetValueForOption(_marketplaceUrlOption);
+                var silencioso = context.ParseResult.GetValueForOption(silenciosoOption);
+                var semCor = context.ParseResult.GetValueForOption(semCorOption);
+
+                return HandleAsync(pasta, ambiente, marketplaceUrl, silencioso, semCor);
+            }
+        );
+    }
+
+    /// <summary>
+    /// Manipula a execução do comando de notificação do marketplace.
+    /// </summary>
+    /// <param name="pasta">Pasta contendo o arquivo manifesto.dat.</param>
+    /// <param name="ambiente">Ambiente de deploy.</param>
+    /// <param name="marketplaceUrl">URL do marketplace.</param>
+    /// <param name="silencioso">Indica se a saída deve ser silenciosa.</param>
+    /// <param name="semCor">Indica se a saída deve ser sem cor.</param>
+    private async Task HandleAsync
+    (
+        string pasta,
+        string ambiente,
+        string? marketplaceUrl,
+        bool silencioso,
+        bool semCor
+    )
+    {
+        if (semCor)
+            _console.Profile.Capabilities.Ansi = false;
+
+        try
+        {
+            if (!silencioso)
+                _console.MarkupLineInterpolated($"[blue][[INFO]] Notificando marketplace para ambiente '{ambiente}'...[/]");
+
+            var manifesto = await _manifestoService.LerManifestoDeployAsync(pasta).ConfigureAwait(false);
+            var urlMarketplaceFinal = _marketplaceService.ObterUrlMarketplace(ambiente, marketplaceUrl);
+
+            var sucesso = await _marketplaceService.NotificarPacoteAsync(urlMarketplaceFinal, manifesto)
+                .ConfigureAwait(false);
+
+            if (!silencioso)
+            {
+                _console.MarkupLine
+                (
+                    sucesso
+                    ? "[green][[SUCCESS]] Notificação concluída com sucesso![/]"
+                    : "[red][[ERROR]] Falha na notificação do marketplace![/]"
+                );
+            }
+        }
+        catch (Exception ex)
+        {
+            _console.MarkupLineInterpolated($"[red][[ERROR]] {ex.Message}[/]");
+
+            throw;
+        }
+    }
+}

--- a/BuildTools/Properties/launchSettings.json
+++ b/BuildTools/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "BuildTools": {
+      "commandName": "Project"
+    },
+    "Notificar": {
+      "commandName": "Project",
+      "commandLineArgs": "notificar-market D:\\projetos\\agent\\_build\\pacote --ambiente producao",
+      "workingDirectory": "D:\\projetos\\agent\\_build\\pacote"
+    }
+  }
+}

--- a/BuildTools/Services/DeployService.cs
+++ b/BuildTools/Services/DeployService.cs
@@ -128,9 +128,12 @@ public sealed class DeployService
                 var manifesto = await LerManifestoAsync(manifestoPath).ConfigureAwait(false);
                 var nomeArquivoCmpkg = CriarNomeArquivoCmpkg(manifesto);
                 var caminhoArquivoCmpkg = fileSystem.Path.Combine(pasta, nomeArquivoCmpkg);
+                console.MarkupLineInterpolated($"[blue][[INFO]] Procurando arquivo: {nomeArquivoCmpkg}[/]");
 
                 if (!fileSystem.File.Exists(caminhoArquivoCmpkg))
                 {
+                    console.MarkupLineInterpolated($"[yellow][[WARN]] Arquivo .cmpkg não encontrado: {nomeArquivoCmpkg}[/]");
+
                     // Procurar por qualquer arquivo .cmpkg na pasta
                     var arquivosCmpkg = fileSystem.Directory.GetFiles(pasta, "*.cmpkg");
 
@@ -141,7 +144,8 @@ public sealed class DeployService
                         continue;
                     }
 
-                    caminhoArquivoCmpkg = arquivosCmpkg[0];
+                    console.MarkupLineInterpolated($"[blue][[INFO]] Renomeando arquivo {fileSystem.Path.GetFileName(arquivosCmpkg[0])} para {nomeArquivoCmpkg}[/]");
+                    fileSystem.File.Move(arquivosCmpkg[0], caminhoArquivoCmpkg, true);
                 }
 
                 var nomeArquivoS3 = fileSystem.Path.GetFileName(caminhoArquivoCmpkg);
@@ -205,10 +209,11 @@ public sealed class DeployService
     private static string CriarNomeArquivoCmpkg(ManifestoDeploy manifesto)
     {
         var versaoLimpa = manifesto.Versao.Replace(".", "_");
+        var nomeLimpo = manifesto.Nome.ToLowerInvariant();
 
         return !string.IsNullOrEmpty(manifesto.SiglaEmpresa)
-            ? $"{manifesto.SiglaEmpresa}-{manifesto.Nome}_{versaoLimpa}.cmpkg"
-            : $"{manifesto.Nome}_{versaoLimpa}.cmpkg";
+            ? $"{manifesto.SiglaEmpresa.ToLowerInvariant()}-{nomeLimpo}_{versaoLimpa}.cmpkg"
+            : $"{nomeLimpo}_{versaoLimpa}.cmpkg";
     }
 
     /// <summary>

--- a/BuildTools/Services/DeployService.cs
+++ b/BuildTools/Services/DeployService.cs
@@ -104,7 +104,9 @@ public sealed class DeployService
         var secretKey = awsSecretKey ?? Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY")
             ?? throw new InvalidOperationException("AWS Secret Key não informada. Configure via parâmetro --aws-secret-key ou variável AWS_SECRET_ACCESS_KEY");
 
-        var region = awsRegion ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1"; return (accessKey, secretKey, region);
+        var region = awsRegion ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
+
+        return (accessKey, secretKey, region);
     }
 
     /// <summary>

--- a/BuildTools/Services/IManifestoService.cs
+++ b/BuildTools/Services/IManifestoService.cs
@@ -12,12 +12,17 @@ public interface IManifestoService
     /// </summary>
     /// <param name="pasta">Caminho da pasta.</param>
     /// <returns>Manifesto lido.</returns>
-    Manifesto LerManifesto(string pasta);
-
-    /// <summary>
+    Manifesto LerManifesto(string pasta);    /// <summary>
     /// Salva o manifesto na pasta informada.
     /// </summary>
     /// <param name="pasta">Caminho da pasta.</param>
     /// <param name="manifesto">Manifesto a ser salvo.</param>
     void SalvarManifesto(string pasta, Manifesto manifesto);
+
+    /// <summary>
+    /// Lê o manifesto de deploy (manifesto.dat) de uma pasta.
+    /// </summary>
+    /// <param name="pasta">Caminho da pasta contendo o arquivo manifesto.dat.</param>
+    /// <returns>Manifesto de deploy lido.</returns>
+    Task<ManifestoDeploy> LerManifestoDeployAsync(string pasta);
 }

--- a/BuildTools/Services/IMarketplaceService.cs
+++ b/BuildTools/Services/IMarketplaceService.cs
@@ -14,4 +14,12 @@ public interface IMarketplaceService
     /// <param name="manifesto">Dados do manifesto do pacote.</param>
     /// <returns>True se a notificação foi bem-sucedida, false caso contrário.</returns>
     Task<bool> NotificarPacoteAsync(string urlMarketplace, ManifestoDeploy manifesto);
+
+    /// <summary>
+    /// Obtém a URL do marketplace baseada no ambiente ou na URL fornecida.
+    /// </summary>
+    /// <param name="ambiente">Ambiente de deploy.</param>
+    /// <param name="urlMarketplace">URL customizada do marketplace.</param>
+    /// <returns>URL final do marketplace.</returns>
+    string ObterUrlMarketplace(string ambiente, string? urlMarketplace = null);
 }

--- a/BuildTools/Services/JwtService.cs
+++ b/BuildTools/Services/JwtService.cs
@@ -62,9 +62,6 @@ public sealed class JwtService(IDateTimeProvider dateTimeProvider) : IJwtService
     /// <returns>Chave com padding aplicado.</returns>
     private static byte[] FazerPaddingChave(byte[] chaveOriginal)
     {
-        if (chaveOriginal.Length >= TAMANHO_CHAVE_MINIMO)
-            return chaveOriginal;
-
         var chavePadded = new byte[TAMANHO_CHAVE_MINIMO];
         Array.Copy(chaveOriginal, chavePadded, chaveOriginal.Length);
 

--- a/BuildTools/Services/JwtService.cs
+++ b/BuildTools/Services/JwtService.cs
@@ -25,10 +25,10 @@ public sealed class JwtService(IDateTimeProvider dateTimeProvider) : IJwtService
         var chaveOriginal = Encoding.UTF8.GetBytes(CHAVE_LEGADA);
         var chaveBase64 = Convert.ToBase64String(chaveOriginal);
         var chaveBytes = Encoding.UTF8.GetBytes(chaveBase64);
-        
+
         // Fazer padding da chave para 256 bits mínimos
         var chavePadded = FazerPaddingChave(chaveBytes);
-        
+
         var signingKey = new SymmetricSecurityKey(chavePadded);
         var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
 

--- a/BuildTools/Services/MarketplaceService.cs
+++ b/BuildTools/Services/MarketplaceService.cs
@@ -63,4 +63,24 @@ public sealed class MarketplaceService(HttpClient httpClient, IJwtService jwtSer
             return false;
         }
     }
+
+    /// <inheritdoc />
+    public string ObterUrlMarketplace(string ambiente, string? urlMarketplace = null)
+    {
+        if (!string.IsNullOrEmpty(urlMarketplace))
+            return urlMarketplace;
+
+        var isTest = string.Equals(Environment.GetEnvironmentVariable("TEST"), "true", StringComparison.OrdinalIgnoreCase);
+
+        if (isTest)
+            return "http://localhost:8888";
+
+        return ambiente.ToLowerInvariant() switch
+        {
+            "stage" => "https://qa-marketplace.ncrcolibri.com.br",
+            "producao" => "https://marketplace.ncrcolibri.com.br",
+            "desenvolvimento" => "https://qa-marketplace.ncrcolibri.com.br",
+            var _ => throw new ArgumentException($"Ambiente '{ambiente}' não é válido. Valores permitidos: 'desenvolvimento', 'producao', 'stage'.", nameof(ambiente))
+        };
+    }
 }

--- a/BuildTools/Startup.cs
+++ b/BuildTools/Startup.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using BuildTools.Commands;
 using BuildTools.Services;
+using BuildTools.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 
@@ -37,9 +38,11 @@ public static class Startup
         services.AddSingleton<IDeployService, DeployService>();
         services.AddSingleton<IS3Service, S3Service>();
         services.AddSingleton<IMarketplaceService, MarketplaceService>();
+
         services.AddSingleton<IJwtService, JwtService>();
         services.AddSingleton<HttpClient>();
         services.AddSingleton<DeployCommand>();
+        services.AddSingleton<NotificarMarketCommand>();
 
         var silenciosoOption = new Option<bool>
         (
@@ -59,9 +62,12 @@ public static class Startup
             description: "Exibe um resumo no formato especificado ao final. Opções: nenhum (padrao), markdown, console. (global)"
         );
 
+        var ambienteOption = AmbienteValidator.CriarOpcaoAmbiente();
+
         services.AddKeyedSingleton("silencioso", silenciosoOption);
         services.AddKeyedSingleton("semCor", semCorOption);
         services.AddKeyedSingleton("resumo", resumoOption);
+        services.AddKeyedSingleton("ambiente", ambienteOption);
 
         return services;
     }
@@ -85,13 +91,17 @@ public static class Startup
 
         rootCommand.AddGlobalOption(silenciosoOption);
         rootCommand.AddGlobalOption(semCorOption);
-        rootCommand.AddGlobalOption(resumoOption);        var empacotarCommand = serviceProvider.GetRequiredService<EmpacotarCommand>();
+        rootCommand.AddGlobalOption(resumoOption);
+
+        var empacotarCommand = serviceProvider.GetRequiredService<EmpacotarCommand>();
         var empacotarScriptsCommand = serviceProvider.GetRequiredService<EmpacotarScriptsCommand>();
         var deployCommand = serviceProvider.GetRequiredService<DeployCommand>();
+        var notificarMarketCommand = serviceProvider.GetRequiredService<NotificarMarketCommand>();
 
         rootCommand.Add(empacotarCommand);
         rootCommand.Add(empacotarScriptsCommand);
         rootCommand.Add(deployCommand);
+        rootCommand.Add(notificarMarketCommand);
 
         return rootCommand;
     }

--- a/BuildTools/Validation/AmbienteValidator.cs
+++ b/BuildTools/Validation/AmbienteValidator.cs
@@ -44,9 +44,6 @@ public static class AmbienteValidator
             {
                 var valor = result.GetValueForOption(opcao);
 
-                if (string.IsNullOrEmpty(valor))
-                    return;
-
                 if (!_ambientesValidos.Contains(valor, StringComparer.OrdinalIgnoreCase))
                     result.ErrorMessage = $"Ambiente '{valor}' inválido. Valores permitidos: {string.Join(", ", _ambientesValidos)}";
             }

--- a/BuildTools/Validation/AmbienteValidator.cs
+++ b/BuildTools/Validation/AmbienteValidator.cs
@@ -1,0 +1,64 @@
+using System.CommandLine;
+
+namespace BuildTools.Validation;
+
+/// <summary>
+/// Validador para ambientes de deploy.
+/// </summary>
+public static class AmbienteValidator
+{
+    private static readonly string[] _ambientesValidos = ["desenvolvimento", "producao", "stage"];
+
+    /// <summary>
+    /// Valida se o ambiente informado é válido.
+    /// </summary>
+    /// <param name="ambiente">Ambiente a ser validado.</param>
+    /// <exception cref="ArgumentException">Lançada quando o ambiente é inválido.</exception>
+    public static void ValidarAmbiente(string ambiente)
+    {
+        if (string.IsNullOrWhiteSpace(ambiente) || !_ambientesValidos.Contains(ambiente, StringComparer.OrdinalIgnoreCase))
+            throw new ArgumentException($"Ambiente '{ambiente}' inválido. Valores permitidos: {string.Join(", ", _ambientesValidos)}");
+    }
+
+    /// <summary>
+    /// Cria uma opção de ambiente pré-configurada com validação.
+    /// </summary>
+    /// <param name="valorPadrao">Valor padrão para a opção.</param>
+    /// <returns>Opção configurada com validação.</returns>
+    public static Option<string> CriarOpcaoAmbiente(string valorPadrao = "desenvolvimento")
+    {
+        var opcao = new Option<string>
+        (
+            aliases: ["--ambiente", "-a"],
+            description: "Ambiente de deploy (\"desenvolvimento\", \"producao\" ou \"stage\")"
+        )
+        {
+            IsRequired = false
+        };
+
+        opcao.SetDefaultValue(valorPadrao);
+
+        opcao.AddValidator
+        (
+            result =>
+            {
+                var valor = result.GetValueForOption(opcao);
+
+                if (string.IsNullOrEmpty(valor))
+                    return;
+
+                if (!_ambientesValidos.Contains(valor, StringComparer.OrdinalIgnoreCase))
+                    result.ErrorMessage = $"Ambiente '{valor}' inválido. Valores permitidos: {string.Join(", ", _ambientesValidos)}";
+            }
+        );
+
+        return opcao;
+    }
+
+    /// <summary>
+    /// Obtém a lista de ambientes válidos.
+    /// </summary>
+    /// <returns>Array com os ambientes válidos.</returns>
+    public static string[] ObterAmbientesValidos()
+        => [.. _ambientesValidos];
+}

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ O comando `notificar-market` permite notificar o marketplace sobre um pacote esp
 
 ### URLs Padrão por Ambiente
 
-- **desenvolvimento**: `https://www.mycolibri.com.br`
-- **homologacao**: `https://mycolibri-homolog.ciasc.gov.br`
-- **producao**: `https://www.mycolibri.com.br`
+- **desenvolvimento**: `https://qa-marketplace.ncrcolibri.com.br`
+- **stage**: `https://qa-marketplace.ncrcolibri.com.br`
+- **producao**: `https://marketplace.ncrcolibri.com.br`
 
 ### Exemplos de Notificação
 


### PR DESCRIPTION
This pull request introduces several updates to the test suite for the `BuildTools` project, focusing on improving test coverage, adding new functionality, and addressing some inconsistencies in existing tests. The most important changes include adding new tests for `NotificarMarketCommand` and `ManifestoService`, updating existing tests for better validation of deployment logic, and refactoring parts of the `JwtServiceTestes` to improve maintainability.

### New Tests and Features:

* **`NotificarMarketCommandTestes`**: Added a comprehensive set of tests to validate the behavior of the `NotificarMarketCommand`, including scenarios for valid parameters, custom marketplace URLs, specific environments, and error handling.

* **`ManifestoServiceTestes`**: Introduced multiple tests for `LerManifestoDeployAsync` to cover scenarios such as reading valid manifests, handling missing or invalid manifests, and ensuring correct default values for empty fields.

### Updates to Deployment Logic:

* **`DeployCommandTestes`**: Added a new `_ambienteOption` to support environment validation and updated the `DeployCommand` constructor to include this option. Adjusted related tests to validate the new behavior. [[1]](diffhunk://#diff-e9920368a4de63aa58e43bb51e58112403b4e7bc8a30b9f483c1c13eb7294a4aR20-R31) [[2]](diffhunk://#diff-e9920368a4de63aa58e43bb51e58112403b4e7bc8a30b9f483c1c13eb7294a4aL40-R45)

* **`DeployServiceTestes`**: Enhanced tests to ensure correct URLs are used for deployments based on environment and custom marketplace URL inputs. Adjusted assertions for file naming conventions to use lowercase and hyphenated formats. [[1]](diffhunk://#diff-cfd00d7c2984155b66c66b20b4b828c62132d7e7ca38e1a7d13f04c88604f899R180) [[2]](diffhunk://#diff-cfd00d7c2984155b66c66b20b4b828c62132d7e7ca38e1a7d13f04c88604f899L597-R602) [[3]](diffhunk://#diff-cfd00d7c2984155b66c66b20b4b828c62132d7e7ca38e1a7d13f04c88604f899L621-R626)

### Refactoring and Improvements:

* **`JwtServiceTestes`**: Refactored token generation tests to replicate the service's key padding logic, ensuring consistency with the `JwtService` implementation. Removed redundant claims validation for `sub` and `iat` claims. [[1]](diffhunk://#diff-be3ebfe2976a0070b18d9481719958bbf3e272125422c489511434a73b2220aaL53-L61) [[2]](diffhunk://#diff-be3ebfe2976a0070b18d9481719958bbf3e272125422c489511434a73b2220aaL131-R135) [[3]](diffhunk://#diff-be3ebfe2976a0070b18d9481719958bbf3e272125422c489511434a73b2220aaR151-R158)

### Minor Fixes:

* Fixed a typo in the `ManifestoServiceTestes` class summary.