### PR TITLE
fix(deploy): corrige nome da chave sigla_empresa no manifesto.

### DIFF
--- a/BuildTools.Testes/Services/DeployServiceTestes.cs
+++ b/BuildTools.Testes/Services/DeployServiceTestes.cs
@@ -690,7 +690,7 @@ public sealed class DeployServiceTestes
         };
 
         if (!string.IsNullOrEmpty(siglaEmpresa))
-            manifesto["siglaEmpresa"] = siglaEmpresa;
+            manifesto["sigla_empresa"] = siglaEmpresa;
 
         return JsonSerializer.Serialize(manifesto);
     }

--- a/BuildTools/Properties/launchSettings.json
+++ b/BuildTools/Properties/launchSettings.json
@@ -7,6 +7,11 @@
       "commandName": "Project",
       "commandLineArgs": "notificar-market D:\\projetos\\agent\\_build\\pacote --ambiente producao",
       "workingDirectory": "D:\\projetos\\agent\\_build\\pacote"
+    },
+    "Deploy": {
+      "commandName": "Project",
+      "commandLineArgs": "deploy D:\\projetos\\agent\\_build\\pacote -si --ambiente producao  --aws-access-key xxxxx --aws-secret-key xxxxx",
+      "workingDirectory": "D:\\projetos\\agent\\_build\\pacote"
     }
   }
 }

--- a/BuildTools/Services/DeployService.cs
+++ b/BuildTools/Services/DeployService.cs
@@ -197,8 +197,11 @@ public sealed class DeployService
         if (dadosCompletos.TryGetValue("develop", out var developObj) && developObj is JsonElement developElement)
             manifesto.Develop = developElement.GetBoolean();
 
-        if (dadosCompletos.TryGetValue("siglaEmpresa", out var empresaObj) && empresaObj is JsonElement empresaElement)
+        if (dadosCompletos.TryGetValue("sigla_empresa", out var empresaObj) && empresaObj is JsonElement empresaElement)
             manifesto.SiglaEmpresa = empresaElement.GetString();
+
+        if (dadosCompletos.TryGetValue("develop", out var developFlagObj) && developFlagObj is JsonElement developFlagElement)
+            manifesto.Develop = developFlagElement.GetBoolean();
 
         return manifesto;
     }

--- a/BuildTools/Services/DeployService.cs
+++ b/BuildTools/Services/DeployService.cs
@@ -198,10 +198,7 @@ public sealed class DeployService
             manifesto.Develop = developElement.GetBoolean();
 
         if (dadosCompletos.TryGetValue("sigla_empresa", out var empresaObj) && empresaObj is JsonElement empresaElement)
-            manifesto.SiglaEmpresa = empresaElement.GetString();
-
-        if (dadosCompletos.TryGetValue("develop", out var developFlagObj) && developFlagObj is JsonElement developFlagElement)
-            manifesto.Develop = developFlagElement.GetBoolean();
+            manifesto.SiglaEmpresa = empresaElement.GetString(); 
 
         return manifesto;
     }


### PR DESCRIPTION
- DeployServiceTestes.cs: Renomeia chave 'siglaEmpresa' para 'sigla_empresa' no manifesto.
- launchSettings.json: Adiciona configuração para comando de deploy com parâmetros de ambiente e credenciais AWS.
- DeployService.cs: Corrige chave de busca para 'sigla_empresa' e adiciona verificação de 'develop' com nova variável.